### PR TITLE
Create Dockerfile for Go application build process

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile.test
+          file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.22.0-alpine AS builder
+
+WORKDIR /app
+
+# 必要なパッケージのインストール
+RUN apk add --no-cache gcc musl-dev
+
+# 依存関係のコピーとダウンロード
+COPY src/backend/go.mod src/backend/go.sum ./
+RUN go mod download
+
+# ソースコードのコピー
+COPY src/backend ./
+
+# アプリケーションのビルド
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./cmd/api
+
+# 最終イメージの作成
+FROM alpine:latest
+
+WORKDIR /app
+
+# タイムゾーンデータのインストール
+RUN apk --no-cache add tzdata
+
+# ビルドしたバイナリのコピー
+COPY --from=builder /app/main .
+
+CMD ["/app/main"]


### PR DESCRIPTION
Establish a new Dockerfile to define the build process for the Go application and update the workflow to use the production Dockerfile instead of the test version.